### PR TITLE
Temporary fix: Method not found: 'throwNullError'

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -82,6 +82,11 @@ class CustomConfig extends Config {
         super(colorMode: ColorMode.custom);
 }
 
+void throwNullError(String colorModeStr, String configStr) {
+  throw FlutterError(
+      'When using `ColorMode.$colorModeStr`, `$configStr` must be set.');
+}
+
 /// todo
 class RandomConfig extends Config {
   RandomConfig() : super(colorMode: ColorMode.random);


### PR DESCRIPTION
Temporary fix for the following errors:

```
wave-0.1.0/lib/config.dart:46:13: Error: Method not found: 'throwNullError'.
            throwNullError('custom', 'colors` or `gradients');
            ^^^^^^^^^^^^^^
wave-0.1.0/lib/config.dart:60:13: Error: Method not found: 'throwNullError'.
            throwNullError('custom', 'durations');
            ^^^^^^^^^^^^^^
wave-0.1.0/lib/config.dart:66:13: Error: Method not found: 'throwNullError'.
            throwNullError('custom', 'heightPercentages');
            ^^^^^^^^^^^^^^
```