### PR TITLE
Enable dynamic wave amplitude adjustments

### DIFF
--- a/lib/wave.dart
+++ b/lib/wave.dart
@@ -348,7 +348,7 @@ class _WaveWidgetState extends State<WaveWidget> with TickerProviderStateMixin {
     if (oldWidget.waveAmplitude != widget.waveAmplitude) {
       setState(() {
         for (int i = 0;
-            i < (widget.config as CustomConfig).durations.length;
+            i < (widget.config as CustomConfig).durations?.length;
             i++) {
           _waveAmplitudes[i] = widget.waveAmplitude + 10;
         }

--- a/lib/wave.dart
+++ b/lib/wave.dart
@@ -341,6 +341,20 @@ class _WaveWidgetState extends State<WaveWidget> with TickerProviderStateMixin {
     _endAnimationTimer?.cancel();
     super.dispose();
   }
+  
+  @override
+  void didUpdateWidget(covariant WaveWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.waveAmplitude != widget.waveAmplitude) {
+      setState(() {
+        for (int i = 0;
+            i < (widget.config as CustomConfig).durations.length;
+            i++) {
+          _waveAmplitudes[i] = widget.waveAmplitude + 10;
+        }
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/wave.dart
+++ b/lib/wave.dart
@@ -348,7 +348,7 @@ class _WaveWidgetState extends State<WaveWidget> with TickerProviderStateMixin {
     if (oldWidget.waveAmplitude != widget.waveAmplitude) {
       setState(() {
         for (int i = 0;
-            i < (widget.config as CustomConfig).durations?.length;
+            i < (widget.config as CustomConfig).durations!.length;
             i++) {
           _waveAmplitudes[i] = widget.waveAmplitude + 10;
         }


### PR DESCRIPTION
With the WaveWidget inside a StreamBuilder it wasn't possible to change the waveAmplitude value based on new stream data. This change allows you to update the waveAmplitude value and have it reflected in the waves that are displayed.

This may not be the best way to achieve this behavior, but if it's useful then great!

I also haven't migrated to null safety in my own project, so I don't know the implications of what I have done here, other than that is builds without errors.